### PR TITLE
Rearrange styles 

### DIFF
--- a/lib/src/BouncyCheckbox.js
+++ b/lib/src/BouncyCheckbox.js
@@ -47,9 +47,8 @@ class BouncyCheckbox extends Component {
     } = this.props;
     return (
       <Animated.View
-        style={[
-          iconStyle || _iconContainer(checked, fillColor, unfillColor),
-          { transform: [{ scale: springValue }] },
+        style={[ { transform: [{ scale: springValue }] },
+          _iconContainer(checked, fillColor, unfillColor),  iconStyle,
         ]}
       >
         {iconComponent || (
@@ -82,17 +81,13 @@ class BouncyCheckbox extends Component {
         {this.renderCheckIcon()}
         <View style={styles.textContainer}>
           <Text
-            style={
-              textStyle ||
-              _textStyle(
+            style={[_textStyle(
                 this.state.checked,
                 textColor,
                 fontFamily,
                 fontSize,
                 disableTextDecoration
-              )
-            }
-          >
+              ), textStyle ]}>
             {text}
           </Text>
         </View>


### PR DESCRIPTION
1. **Motivation:**

 In project wanted to change borderWidth of icon. But for this I have to create the same styles as _iconContainer. So, in order,  just to change borderWidth writing the same amount of styles violets programming concepts DRY(Don't Repeat Yourself). So I just rearranged styles, so that anyone who wants to the change any of these  styles
 ```
    width: 25,
    height: 25,
    borderWidth: 1,
    borderRadius: 20,
    borderColor: "#ffc484",
```
Only sending one style item within iconStyle props is enough. It will only override that style item. So it is flexible I guess


1. **Example Problem now:**

Scenario: I want to change borderColor of icon to 'red'. 

So what I basically do:

I create the same style: 
```
export const _iconContainer = (checked, fillColor, unfillColor) => {
  return {
    width: 25,
    height: 25,
    borderWidth: 1,
    borderRadius: 20,
> borderColor: "red",
    alignItems: "center",
    justifyContent: "center",
    backgroundColor: checked ? fillColor : unfillColor,
  };
};
```
**Usage**

```
<BouncyCheckbox
  isChecked
  textColor="#000"
  fillColor="red"
  text="Buy tickets for concert 🎉 🎊"
>  iconStyle={_iconContainer(checked, fillColor, unfillColor)}
/>
```
I just will change borderColor to  "red". But repeating the same amount of styles.

1. **Version I am proposing**

Scenario: I want to change borderColor of icon to 'red'. 

Just create simple style

```
iconStyleOverride : {
  borderColor: "red"
}
```
**Usage** 
```
<BouncyCheckbox
  isChecked
  textColor="#000"
  fillColor="red"
  text="Buy tickets for concert 🎉 🎊"
  > iconStyle={iconStyleOverride}
/>
```

So just rearranging styles  anyone will be able to change  styles of textStyle and iconStyle. Thus, nobody will not repeat the same amount of styles again.

Thank you for time. Fill free to ask questions.
 