### PR TITLE
added CustomTextComponent props

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npm i react-native-bouncy-checkbox
   - `iconStyle`
   - `bounceEffect`
   - `bounceFriction`
+  - `CustomTextComponent`
 
 ## Import
 
@@ -77,7 +78,9 @@ import BouncyCheckbox from "react-native-bouncy-checkbox";
 
 | Property             |   Type    |     Default      | Description                                                                                                                                |
 | -------------------- | :-------: | :--------------: | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| text                 |  string   |    undefined     | set the checkbox's text                                                                                                                    |
+| text                 |  string   |    undefined     | set the checkbox's 
+text
+| CustomTextComponent  | component |    undefined     | set the checkbox's text with custom component to make it look however you want                                                                                                                      |
 | onPress              | function  |       null       | set your own onPress functionality after the bounce effect, callback receives the next `isChecked` boolean if disableBuiltInState is false |
 | disableText          |  boolean  |      false       | if you want to use checkbox without text, you can enable it                                                                                |
 | size                 |  number   |        25        | size of `width` and `height` of the checkbox                                                                                               |

--- a/lib/BouncyCheckbox.tsx
+++ b/lib/BouncyCheckbox.tsx
@@ -18,6 +18,7 @@ export interface IBouncyCheckboxProps {
   style?: StyleProp<ViewStyle>;
   size?: number;
   text?: string;
+  CustomTextComponent?: React.ElementType;
   iconStyle?: any;
   textStyle?: StyleProp<TextStyle>;
   fillColor?: string;
@@ -147,6 +148,18 @@ class BouncyCheckbox extends React.Component<IBouncyCheckboxProps, IState> {
     );
   };
 
+  renderCheckBoxCustomTextComponent = () => {
+    const {
+      text,
+      CustomTextComponent
+    } = this.props;
+    return (
+      !text && CustomTextComponent && (
+        <CustomTextComponent/>
+      )
+    );
+  };
+
   render() {
     const { style, TouchableComponent = TouchableOpacity } = this.props;
     return (
@@ -157,6 +170,7 @@ class BouncyCheckbox extends React.Component<IBouncyCheckboxProps, IState> {
       >
         {this.renderCheckIcon()}
         {this.renderCheckboxText()}
+        {this.renderCheckBoxCustomTextComponent()}
       </TouchableComponent>
     );
   }


### PR DESCRIPTION
added **CustomTextComponent** props  so that instead of just simple string text beside checkbox it's possible to do as wish designed text beside checkbox instead of just a simple string text

_I was facing this when i was implementing this package in our company project today,  so decided to contribute here by adding a way so we can do use custom component which works just like the text works to check and uncheck checkbox._

