### PR TITLE
feat: Synthetic press functionality depending on isChecked state update

### DIFF
--- a/lib/BouncyCheckbox.tsx
+++ b/lib/BouncyCheckbox.tsx
@@ -72,6 +72,12 @@ class BouncyCheckbox extends React.Component<IBouncyCheckboxProps, IState> {
     this.setState({ checked: this.props.isChecked || false });
   }
 
+  componentDidUpdate(prevProps: { isChecked: boolean | undefined }) {
+    if (this.props.isChecked !== prevProps.isChecked) {
+      this.setState({ checked: this.props.isChecked || false });
+    }
+  }
+
   bounceEffect = (value: number, velocity: number, bounciness: number) => {
     const { useNativeDriver = true } = this.props;
     Animated.spring(this.state.bounceValue, {


### PR DESCRIPTION
Makes checked state respond to isChecked prop changes so that you don't need to use disableBuiltInState and useRef and can easily toggle checkbox when you need synthetic press functionality.