### PR TITLE
chore: change type for text prop

### DIFF
--- a/lib/BouncyCheckbox.tsx
+++ b/lib/BouncyCheckbox.tsx
@@ -11,6 +11,7 @@ import {
   ImageSourcePropType,
   TouchableWithoutFeedbackProps,
   ImageStyle,
+  TextProps,
 } from "react-native";
 import styles, { _textStyle } from "./BouncyCheckbox.style";
 
@@ -21,7 +22,7 @@ type BaseTouchableProps = Pick<
 
 export interface IBouncyCheckboxProps extends BaseTouchableProps {
   size?: number;
-  text?: string;
+  text?: TextProps["children"];
   fillColor?: string;
   isChecked?: boolean;
   unfillColor?: string;


### PR DESCRIPTION
`text` prop might be any node component so you can pass custom nested `Text`:

```ts
<BouncyCheckbox
    {...props}
    text={<Text {...textProps}>Some text...</Text>}
/>
```