### PR TITLE
fix: Invariant Violation: Text strings must be rendered within a <Text> component

### DIFF
--- a/lib/BouncyCheckbox.tsx
+++ b/lib/BouncyCheckbox.tsx
@@ -110,13 +110,13 @@ class BouncyCheckbox extends React.Component<IBouncyCheckboxProps, IState> {
         <View
           style={[styles.innerIconContainer(size, fillColor), innerIconStyle]}
         >
-          {iconComponent ||
+          {iconComponent ?
             (checkStatus && (
               <ImageComponent
                 source={checkIconImageSource}
                 style={[styles.iconImageStyle, iconImageStyle]}
               />
-            ))}
+            )) : null}
         </View>
       </Animated.View>
     );


### PR DESCRIPTION
I'm getting an error in some situations when `iconComponent` is undefined - the ternary syntax fails because `undefined` is printed into the document, leading to:

> Invariant Violation: Text strings must be rendered within a <Text> component

This syntax, annoyingly, fixes the issue, because react will correctly render nothing here, instead of the text "undefined".

Why and under what circumstances iconComponent can be undefined, I'm not quite sure yet, but either way this prevents the crash.

Thank you for the nice library, I'm using it to build an app for my wife!