### PR TITLE
Add bind isChecked to onPress

### DIFF
--- a/lib/BouncyCheckbox.tsx
+++ b/lib/BouncyCheckbox.tsx
@@ -59,6 +59,16 @@ const BouncyCheckbox: React.ForwardRefRenderFunction<
   }, [isChecked, setChecked]);
 
   const onCheckboxPress = useCallback(() => {
+    if (isChecked !== undefined) {
+      syntheticBounceAnimation(
+        bounceEffectIn,
+        bounceEffectOut,
+        bounceVelocityOut,
+        bouncinessOut,
+      );
+      onPress && onPress(isChecked);
+      return;
+    }
     setChecked(!checked, (newCheckedValue) => {
       syntheticBounceAnimation(
         bounceEffectIn,
@@ -69,6 +79,7 @@ const BouncyCheckbox: React.ForwardRefRenderFunction<
       onPress && onPress(newCheckedValue);
     });
   }, [
+    isChecked,
     bounceEffectIn,
     bounceEffectOut,
     bounceVelocityOut,
@@ -83,10 +94,14 @@ const BouncyCheckbox: React.ForwardRefRenderFunction<
     if (!onLongPress) {
       return;
     }
+    if (isChecked !== undefined) {
+      onLongPress && onLongPress(isChecked);
+      return;
+    }
     setChecked(!checked, (newCheckedValue) => {
       onLongPress && onLongPress(newCheckedValue);
     });
-  }, [checked, onLongPress, setChecked]);
+  }, [isChecked, checked, onLongPress, setChecked]);
 
   useImperativeHandle(ref, () => ({ onCheckboxPress, onCheckboxLongPress }), [
     onCheckboxPress,

--- a/lib/BouncyCheckbox.tsx
+++ b/lib/BouncyCheckbox.tsx
@@ -59,25 +59,17 @@ const BouncyCheckbox: React.ForwardRefRenderFunction<
   }, [isChecked, setChecked]);
 
   const onCheckboxPress = useCallback(() => {
-    if (isChecked !== undefined) {
+    const handlePress = (value: boolean) => {
+      onPress && onPress(value);
       syntheticBounceAnimation(
         bounceEffectIn,
         bounceEffectOut,
         bounceVelocityOut,
         bouncinessOut,
       );
-      onPress && onPress(isChecked);
-      return;
     }
-    setChecked(!checked, (newCheckedValue) => {
-      syntheticBounceAnimation(
-        bounceEffectIn,
-        bounceEffectOut,
-        bounceVelocityOut,
-        bouncinessOut,
-      );
-      onPress && onPress(newCheckedValue);
-    });
+    if (isChecked !== undefined) handlePress(isChecked)
+    else setChecked(!checked, handlePress);
   }, [
     isChecked,
     bounceEffectIn,
@@ -91,16 +83,9 @@ const BouncyCheckbox: React.ForwardRefRenderFunction<
   ]);
 
   const onCheckboxLongPress = useCallback(() => {
-    if (!onLongPress) {
-      return;
-    }
-    if (isChecked !== undefined) {
-      onLongPress && onLongPress(isChecked);
-      return;
-    }
-    setChecked(!checked, (newCheckedValue) => {
-      onLongPress && onLongPress(newCheckedValue);
-    });
+    if (!onLongPress) return;
+    if (isChecked !== undefined) onLongPress(isChecked);
+    else setChecked(!checked, onLongPress);
   }, [isChecked, checked, onLongPress, setChecked]);
 
   useImperativeHandle(ref, () => ({ onCheckboxPress, onCheckboxLongPress }), [

--- a/lib/BouncyCheckbox.tsx
+++ b/lib/BouncyCheckbox.tsx
@@ -59,17 +59,14 @@ const BouncyCheckbox: React.ForwardRefRenderFunction<
   }, [isChecked, setChecked]);
 
   const onCheckboxPress = useCallback(() => {
-    const handlePress = (value: boolean) => {
-      onPress && onPress(value);
-      syntheticBounceAnimation(
-        bounceEffectIn,
-        bounceEffectOut,
-        bounceVelocityOut,
-        bouncinessOut,
-      );
-    }
-    if (isChecked !== undefined) handlePress(isChecked)
-    else setChecked(!checked, handlePress);
+    if (isChecked === undefined) setChecked(!checked, onPress);
+    else if (onPress) onPress(isChecked);
+    syntheticBounceAnimation(
+      bounceEffectIn,
+      bounceEffectOut,
+      bounceVelocityOut,
+      bouncinessOut,
+    );
   }, [
     isChecked,
     bounceEffectIn,


### PR DESCRIPTION
Hi.

I add bind to isChecked prop. Because when isChecked is defined as props from an app `example: <BouncyCheckbox isChecked={someValue} />`, and onPress action happened it don't see that isChecked is defined and set new checked (by toggling current checked value) regardless of isChecked prop. And we have two different states - lib state checked for example is false and app state checked for example is true. It means we have unchecked (false) checkbox on screen and checked (true) state app value. 

Please check the changes, thanks!